### PR TITLE
chore: add .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Salesforce Open Source project configuration
+# Learn more: https://github.com/salesforce/oss-template
+#ECCN:Open Source
+#GUSINFO:Open Source,Open Source Workflow


### PR DESCRIPTION
###  Summary

This pull request adds a `.github/CODEOWNERS` file to adhere to the Salesforce Open Source project requirements.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
